### PR TITLE
Update profile_add.twig to load meta child template from namespace

### DIFF
--- a/templates/admin/profile_add.twig
+++ b/templates/admin/profile_add.twig
@@ -43,7 +43,7 @@
                 {{ form_errors(form_profile.password.second) }}
                 {{ form_widget(form_profile.password.second, { 'attr': {'class': 'form-control large'} }) }}
 
-                {% include 'profile_edit_meta.twig' ignore missing %}
+                {% include '@MembersAdmin/profile_edit_meta.twig' ignore missing %}
 
                 <br>
             <div class="hidden">


### PR DESCRIPTION
to be able to override that part in a custom extension, we need the child template be relative to a namespace : exactly as in profile_edit.twig.