### PR TITLE
Always ensure account meta is an array

### DIFF
--- a/src/Storage/Repository/AccountMeta.php
+++ b/src/Storage/Repository/AccountMeta.php
@@ -33,7 +33,7 @@ class AccountMeta extends AbstractMembersRepository
             return $this->getPager($query, 'guid');
         }
 
-        $meta = $this->findWith($query);
+        $meta = $this->findWith($query) ?: [];
 
         /** @var Entity\AccountMeta $value */
         foreach ($meta as $key => $value) {


### PR DESCRIPTION
Ensure that account meta always returns an array.

See related https://github.com/bolt/bolt/issues/5555

I received this error when:

1. Registering a new user (members/profile/register)
2. Following the verification link.