### PR TITLE
Pager PostgreSQL fixup

### DIFF
--- a/src/Storage/Repository/AbstractMembersRepository.php
+++ b/src/Storage/Repository/AbstractMembersRepository.php
@@ -71,10 +71,11 @@ abstract class AbstractMembersRepository extends Repository
             $callback = function (QueryBuilder $queryBuilder) use ($select, $countField) {
                 $queryBuilder
                     ->select($select)
-                    ->addGroupBy($countField)
+                    ->orderBy(1)
                     ->setMaxResults(1)
                 ;
             };
+
             $adapter = new DoctrineDbalAdapter($query, $callback);
             $this->pager = new Pager\Pager($adapter, $this->getEntityBuilder());
         }

--- a/src/Storage/Repository/AbstractMembersRepository.php
+++ b/src/Storage/Repository/AbstractMembersRepository.php
@@ -66,10 +66,12 @@ abstract class AbstractMembersRepository extends Repository
     public function getPager(QueryBuilder $query, $column)
     {
         if ($this->pager === null) {
-            $select = $this->createSelectForCountField(static::ALIAS . '.' . $column);
-            $callback = function (QueryBuilder $queryBuilder) use ($select) {
+            $countField = static::ALIAS . '.' . $column;
+            $select = $this->createSelectForCountField($countField);
+            $callback = function (QueryBuilder $queryBuilder) use ($select, $countField) {
                 $queryBuilder
                     ->select($select)
+                    ->addGroupBy($countField)
                     ->setMaxResults(1)
                 ;
             };


### PR DESCRIPTION
Fixes #59

I updated the count() query in the pager to force the _order by_ to 1. Another solution could have been adding a _group by_ clause instead but I found this one simpler. 