### PR TITLE
prevent autocompletion of password fields for password change pages

### DIFF
--- a/templates/admin/profile_add.twig
+++ b/templates/admin/profile_add.twig
@@ -37,11 +37,11 @@
 
                 {{ form_label(form_profile.password.first, null, {'label_attr': {'class': 'main col-xs-12'}}) }}
                 {{ form_errors(form_profile.password.first) }}
-                {{ form_widget(form_profile.password.first, { 'attr': {'class': 'form-control large'} }) }}
+                {{ form_widget(form_profile.password.first, { 'attr': {'class': 'form-control large', 'autocomplete': 'new-password'} }) }}
 
                 {{ form_label(form_profile.password.second, null, {'label_attr': {'class': 'main col-xs-12'}}) }}
                 {{ form_errors(form_profile.password.second) }}
-                {{ form_widget(form_profile.password.second, { 'attr': {'class': 'form-control large'} }) }}
+                {{ form_widget(form_profile.password.second, { 'attr': {'class': 'form-control large', 'autocomplete': 'new-password'} }) }}
 
                 {% include '@MembersAdmin/profile_edit_meta.twig' ignore missing %}
 

--- a/templates/admin/profile_edit.twig
+++ b/templates/admin/profile_edit.twig
@@ -37,11 +37,11 @@
 
                 {{ form_label(form_profile.password.first, null, {'label_attr': {'class': 'main col-xs-12'}}) }}
                 {{ form_errors(form_profile.password.first) }}
-                {{ form_widget(form_profile.password.first, { 'attr': {'class': 'form-control large'}, 'required': false }) }}
+                {{ form_widget(form_profile.password.first, { 'attr': {'class': 'form-control large', 'autocomplete': 'new-password'}, 'required': false }) }}
 
                 {{ form_label(form_profile.password.second, null, {'label_attr': {'class': 'main col-xs-12'}}) }}
                 {{ form_errors(form_profile.password.second) }}
-                {{ form_widget(form_profile.password.second, { 'attr': {'class': 'form-control large'}, 'required': false }) }}
+                {{ form_widget(form_profile.password.second, { 'attr': {'class': 'form-control large', 'autocomplete': 'new-password'}, 'required': false }) }}
 
                 {% include '@MembersAdmin/profile_edit_meta.twig' ignore missing %}
 

--- a/templates/profile/register.twig
+++ b/templates/profile/register.twig
@@ -35,8 +35,8 @@
             {% if transitional %}
                 {% do form_register.password.setRendered %}
             {% else %}
-                {{ form_row(form_register.password.first) }}
-                {{ form_row(form_register.password.second) }}
+                {{ form_widget(form_profile.password.first, { 'attr': {'autocomplete': 'new-password'}}) }}
+                {{ form_widget(form_profile.password.second, { 'attr': {'autocomplete': 'new-password'}}) }}
             {% endif %}
 
                 <br>


### PR DESCRIPTION
This should add an html5 attribute to all new/edit password fields to prevent the annoying password autofill in compliant browsers.

Some info on the specification.
1. https://html.spec.whatwg.org/multipage/forms.html#autofill
2. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocomplete
3. https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion