### PR TITLE
Fix const name and adding Trans

### DIFF
--- a/doc/extending/adding-meta-fields.md
+++ b/doc/extending/adding-meta-fields.md
@@ -52,7 +52,7 @@ The extension loading class will need a pre-save and form build events.
      */
     public function onRequest(FormBuilderEvent $event)
     {
-        if ($event->getName() !== MembersForms::FORM_PROFILE_EDIT && $event->getName() !== MembersForms::FORM_PROFILE_VIEW) {
+        if ($event->getName() !== MembersForms::PROFILE_EDIT && $event->getName() !== MembersForms::PROFILE_VIEW) {
             return;
         }
         $app = $this->getContainer();
@@ -79,6 +79,7 @@ use Bolt\Extension\Bolt\Members\Form\Type\ProfileEditType as MembersProfileEditT
 use Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
+use Bolt\Translation\Translator as Trans;
 
 class ProfileEditType extends MembersProfileEditType
 {


### PR DESCRIPTION
648e372989f3d157e7d51e93c0657b539fa4b206 changed the name, and it was missing a `use` for the translator