### PR TITLE
Make the meta fields blend in by default

### DIFF
--- a/doc/extending/adding-meta-fields.md
+++ b/doc/extending/adding-meta-fields.md
@@ -91,7 +91,13 @@ class ProfileEditType extends MembersProfileEditType
         parent::buildForm($builder, $options);
 
         $builder
-            ->add('postcode', Type\TextType::class,   [
+            ->add('postcode', Type\TextType::class, [
+                'label_attr'  => [
+                    'class' => 'main col-xs-12'
+                ],
+                'attr'        => [
+                    'class' => 'form-control large'
+                ],
                 'label'       => Trans::__('Postcode:'),
                 'constraints' => [
                 ],

--- a/doc/extending/adding-meta-fields.md
+++ b/doc/extending/adding-meta-fields.md
@@ -96,7 +96,8 @@ class ProfileEditType extends MembersProfileEditType
                     'class' => 'main col-xs-12'
                 ],
                 'attr'        => [
-                    'class' => 'form-control large'
+                    'class'       => 'form-control large',
+                    'placeholder' => Trans::__('Your postcode...')
                 ],
                 'label'       => Trans::__('Postcode:'),
                 'constraints' => [


### PR DESCRIPTION
This makes the suggested meta fields form config blend in with the other fields.

Before:
![before](https://cloud.githubusercontent.com/assets/5096632/23217198/be014d4e-f918-11e6-9985-5e4263d451a8.png)

After:
![after](https://cloud.githubusercontent.com/assets/5096632/23217205/c2d2ce10-f918-11e6-8155-55dd79040f98.png)
